### PR TITLE
#23 basic checker tests

### DIFF
--- a/lib/checker.js
+++ b/lib/checker.js
@@ -1967,5 +1967,5 @@ function check(code) {
 		}
 	}
 
-	return ast;
+	return {ast, outputMessages};
 }

--- a/lib/checker.js
+++ b/lib/checker.js
@@ -1924,7 +1924,7 @@ function addOutputMessage({ type = "info", id = -1, text = "?",  node = {}, } = 
 	outputMessages.push({ type, id, text: textWithLoc, });
 }
 
-function check(code) {
+function check(code, {verbose=true}) {
 	var ast = babylon.parse(code);
 
 	multipass: for (let passCount = 1; passCount <= PASS_LIMIT; passCount++) {
@@ -1958,12 +1958,14 @@ function check(code) {
 		break;
 	}
 
-	for (let msg of outputMessages) {
-		if (msg.type == "error") {
-			console.error(msg.text);
-		}
-		else {
-			console.log(msg.text);
+	if (verbose){
+		for (let msg of outputMessages) {
+			if (msg.type == "error") {
+				console.error(msg.text);
+			}
+			else {
+				console.log(msg.text);
+			}
 		}
 	}
 

--- a/tests/any.data.js
+++ b/tests/any.data.js
@@ -1,0 +1,4 @@
+var a = any``;
+a = "hello";  // OK
+a = 1; // also OK because `a` is still type `any`
+var b = a + 2;   // error: mixed operand types: 'any' and 'number'

--- a/tests/any.data.js
+++ b/tests/any.data.js
@@ -1,4 +1,0 @@
-var a = any``;
-a = "hello";  // OK
-a = 1; // also OK because `a` is still type `any`
-var b = a + 2;   // error: mixed operand types: 'any' and 'number'

--- a/tests/tests.checker.js
+++ b/tests/tests.checker.js
@@ -1,7 +1,6 @@
 "use strict";
 var path = require("path");
 var Typl = require(path.join(__dirname, "..", "lib"));
-var fs = require("fs");
 
 // QUnit.test( "Checker: API", function test(assert){
 // 	assert.expect( 1 );
@@ -26,17 +25,12 @@ QUnit.test("Checker: API", function test(assert) {
 
 QUnit.test("Checker: any", function test(assert) {
   assert.expect(2);
-  let contents = fs.readFileSync(path.resolve('tests', 'any.data.js'), "utf-8");
-  let code = `var a = any;
+  let code = `var a = any\`\`;
 	a = "hello";  
 	a = 1; 
 	var b = a + 2;`
   
-  // passing string to checker does not work as expected
-  // let { outputMessages } = Typl.Checker.check(code);
-
-  // passing a content of a file DOES work OK
-  let { outputMessages } = Typl.Checker.check(contents);
+  let { outputMessages } = Typl.Checker.check(code);
 
   let errors = outputMessages.filter(m => m.type == "error")
   assert.equal(outputMessages.length, 4, 'total output length');

--- a/tests/tests.checker.js
+++ b/tests/tests.checker.js
@@ -1,43 +1,137 @@
 "use strict";
 var path = require("path");
-var Typl = require(path.join(__dirname, "..", "lib"));
+var Typl = require(path.join(__dirname,"..","lib"));
 
-// QUnit.test( "Checker: API", function test(assert){
-// 	assert.expect( 1 );
+QUnit.test( "Checker: API", function test(assert){
+	assert.expect( 1 );
+	assert.ok( _isFunction( Typl.Checker.check ), "check(..)" );
+} );
 
-// 	assert.ok( _isFunction( Checker.check ), "check(..)" );
-// } );
+QUnit.test( "Checker: #6 number sub-types", function test(assert){
+	assert.expect(2);
+	let code  = `var a = int\`3\`;
+	a = 4;														// error, can't assign number to int
+	
+	var b = 5;
+	b = int\`6\`;											// no error
+	
+	var c = finite\`7\`;
+	b = c;														// no error
+	c = b;														// error can't assign number to finite`
 
-// QUnit.test( "Checker: check(..)", function test(assert){
-// 	var rExpected = undefined;
+	let {outputMessages} = Typl.Checker.  check(code, {verbose:false});
+	let errors = outputMessages.filter(m => m.type == "error")
+	assert.equal(outputMessages.length, 5, 'total output length');
+	assert.equal(errors.length, 2, 'num errors');
+} );
 
-// 	var rActual = Checker.check("var x;");
+QUnit.test( "Checker: #7 enforce bool type check in conditionals", function test(assert){
+	assert.expect(2);
+	let code  = `var i = 3 > 9;	// becomes bool but with error
+	function foo(){
+		return "ddd";										// foo returns string
+	}
+	
+	function bar(){
+		return "d" + 3 > 9;
+	}
+	
+	if(i){}														// pass
+	while(i){}												// pass
+	do{} while(i)											// pass
+	let a = i ? 1 : 0;								// pass
+	
+	if(foo()){}												// error
+	while(foo()){}										// error
+	do{} while(foo())									// error
+	let b = foo() ? 1 : 0;						// error`
 
-// 	assert.expect( 1 );
-// 	assert.strictEqual( rActual, rActual, "check(..)" );
-// } );
+	let {outputMessages} = Typl.Checker.check(code, {verbose:false});
+	let errors = outputMessages.filter(m => m.type == "error")
+	assert.equal(outputMessages.length, 18, 'total output length');
+	assert.equal(errors.length, 6, 'num errors');
+} );
 
-QUnit.test("Checker: API", function test(assert) {
-  assert.expect(1);
-  assert.ok(_isFunction(Typl.Checker.check), "check(..)");
-});
+QUnit.test( "Checker: #8 any", function test(assert){
+	assert.expect(2);
+	let code  = `var a = any\`\`;
+	a = "hello";											// OK
+	a = 1;														// also OK because a is still type any
+	var b = a + 2;										// error: mixed operand types: any and number`
+
+	let {outputMessages} = Typl.Checker.check(code, {verbose:false});
+	let errors = outputMessages.filter(m => m.type == "error")
+	assert.equal(outputMessages.length, 16, 'total output length');
+	assert.equal(errors.length, 1, 'num errors');
+} );
+
+QUnit.test( "Checker: #9 undef", function test(assert){
+	assert.expect(2);
+	let code  = `var a;
+	var b = a + 1;										// error: mixed operand types
+	
+	a = 2;														// no error, overwrites a to type number
+	b = a + 2;												// no error
+	
+	var c = undefined;
+	c = 3;														// no error, overwrites c to type number
+	
+	var d = undef\`\`;
+	d = 4;														// error, d is already tagged-type of undef`
+	
+	let {outputMessages} = Typl.Checker.check(code, {verbose:false});
+	let errors = outputMessages.filter(m => m.type == "error")
+	assert.equal(outputMessages.length, 24, 'total output length');
+	assert.equal(errors.length, 2, 'num errors');
+} );
 
 
-QUnit.test("Checker: any", function test(assert) {
-  assert.expect(2);
-  let code = `var a = any\`\`;
-	a = "hello";  
-	a = 1; 
-	var b = a + 2;`
-  
-  let { outputMessages } = Typl.Checker.check(code);
+QUnit.test( "Checker: #17 Narrower number type inference", function test(assert){
+	assert.expect(2);
+	let code  = `var x = 3;						// infer 'int'
+	var y = 3.14;											// infer 'finite'
+	var z = NaN;											// infer 'number'
+	
+	x = 2.2														// error, expected int, got number
+	y = NaN														// error, expected finite, got number
+	z = "a"														// error, expected number, found string`
+	
+	let {outputMessages} = Typl.Checker.check(code, {verbose:false});
+	let errors = outputMessages.filter(m => m.type == "error")
+	assert.equal(outputMessages.length, 29, 'total output length');
+	assert.equal(errors.length, 3, 'num errors');
+} );
 
-  let errors = outputMessages.filter(m => m.type == "error")
-  assert.equal(outputMessages.length, 4, 'total output length');
-  assert.equal(errors.length, 1, 'num errors');
-});
+QUnit.test( "Checker: #33 Treat IIFE as a validated call-expression", function test(assert){
+	assert.expect(2);
+	let code  = `var y = (function foo(x = number){
+		return String(x);
+	})(true);`
+	
+	let {outputMessages} = Typl.Checker.check(code, {verbose:false});
+	let errors = outputMessages.filter(m => m.type == "error")
+	assert.equal(outputMessages.length, 32, 'total output length');
+	assert.equal(errors.length, 1, 'num errors');
+} );
+
+QUnit.test( "Checker: #34 check tagged-type simple literals", function test(assert){
+	assert.expect(2);
+	let code  = `int\`3.1\`							// should report an error
+	finite\`3.1\`												// OK
+	bool\`${true}\`											// OK
+	bool\`true\`												// OK
+	bool\`ok\`													// error`
+	
+	let {outputMessages} = Typl.Checker.check(code, {verbose:false});
+	let errors = outputMessages.filter(m => m.type == "error")
+	assert.equal(outputMessages.length, 34, 'total output length');
+	assert.equal(errors.length, 2, 'num errors');
+} );
+
+
+
 
 
 function _isFunction(v) {
-  return typeof v == "function";
+	return typeof v == "function";
 }

--- a/tests/tests.checker.js
+++ b/tests/tests.checker.js
@@ -1,24 +1,49 @@
 "use strict";
+var path = require("path");
+var Typl = require(path.join(__dirname, "..", "lib"));
+var fs = require("fs");
 
-QUnit.test( "Checker: API", function test(assert){
-	assert.expect( 1 );
+// QUnit.test( "Checker: API", function test(assert){
+// 	assert.expect( 1 );
 
-	assert.ok( _isFunction( Checker.check ), "check(..)" );
-} );
+// 	assert.ok( _isFunction( Checker.check ), "check(..)" );
+// } );
 
-QUnit.test( "Checker: check(..)", function test(assert){
-	var rExpected = undefined;
+// QUnit.test( "Checker: check(..)", function test(assert){
+// 	var rExpected = undefined;
 
-	var rActual = Checker.check("var x;");
+// 	var rActual = Checker.check("var x;");
 
-	assert.expect( 1 );
-	assert.strictEqual( rActual, rActual, "check(..)" );
-} );
+// 	assert.expect( 1 );
+// 	assert.strictEqual( rActual, rActual, "check(..)" );
+// } );
+
+QUnit.test("Checker: API", function test(assert) {
+  assert.expect(1);
+  assert.ok(_isFunction(Typl.Checker.check), "check(..)");
+});
 
 
+QUnit.test("Checker: any", function test(assert) {
+  assert.expect(2);
+  let contents = fs.readFileSync(path.resolve('tests', 'any.data.js'), "utf-8");
+  let code = `var a = any;
+	a = "hello";  
+	a = 1; 
+	var b = a + 2;`
+  
+  // passing string to checker does not work as expected
+  // let { outputMessages } = Typl.Checker.check(code);
 
+  // passing a content of a file DOES work OK
+  let { outputMessages } = Typl.Checker.check(contents);
+
+  let errors = outputMessages.filter(m => m.type == "error")
+  assert.equal(outputMessages.length, 4, 'total output length');
+  assert.equal(errors.length, 1, 'num errors');
+});
 
 
 function _isFunction(v) {
-	return typeof v == "function";
+  return typeof v == "function";
 }


### PR DESCRIPTION
You will notice that test #6 now fails, but that's expected due to #28 being now in place. I just let it fail for you to see the original requirement and how it fails with the upgraded functionality. 

Failed: 'Checker: #6 number sub-types' (1/2)

