### PR TITLE
#39 tests for array checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ All code and documentation are (c) 2019 Kyle Simpson and released under the [MIT
 ## Run
 
 ```js
+bin/typl --file=./test-snippets/code.js
+```
+or
+
+```js
 node ./lib/cli.js --file=./test-snippets/code.js
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,15 @@ The JavaScript Type Linter. Coming Soon.
 ## License
 
 All code and documentation are (c) 2019 Kyle Simpson and released under the [MIT License](http://getify.mit-license.org/). A copy of the MIT License [is also included](LICENSE.txt).
+
+## Run
+
+```js
+node ./lib/cli.js --file=./test-snippets/code.js
+```
+
+## Test
+
+```
+npm test
+```

--- a/scripts/node-tests.js
+++ b/scripts/node-tests.js
@@ -26,5 +26,6 @@ global.QUnit = require("qunit");
 require(path.join("..","tests","qunit.config.js"));
 require(path.join("..","tests","tests.runtime.js"));
 require(path.join("..","tests","tests.checker.js"));
+require(path.join("..", "tests", "tests.checker.arrays.js"));
 
 QUnit.start();

--- a/tests/tests.checker.arrays.js
+++ b/tests/tests.checker.arrays.js
@@ -1,0 +1,172 @@
+"use strict";
+
+var path = require("path");
+var TL = require(path.join(__dirname, "..", "lib"));
+
+QUnit.test("Checker: #39 array-of-type annotation", function test(assert) {
+	assert.expect(1);
+	let code = `
+		var x = array\`int[]\`;
+		var y = array\`int[]\`\`[1,2,3]\`;
+		var z = array\`int[]\`\`\${y}\`;
+		
+		x = [1,2,3];	// OK!
+		y = [4,5,6];	// OK!
+		z = x;				// OK!
+		z = ["a","b","c"]		// error
+	`;
+	let { outputMessages, } = TL.Checker.check(code, { verbose: false, });
+	let errors = outputMessages.filter(function isError(msg) { return msg.type == "error"; });
+	// assert.equal(outputMessages.length, 8, "total output length");
+	assert.equal(errors.length, 1, "num errors");
+});
+
+QUnit.test("Checker: #39 Non-empty arrays ", function test(assert) {
+	assert.expect(1);
+	let code = `
+		var x = array\`int[]\`\`\${ [] }\`;		// OK, allowed to be empty
+		var y = array\`int[+]\`\`\${ [] }\`;		// error, not allowed to be empty
+		y = [] // error
+	`;
+	let { outputMessages, } = TL.Checker.check(code, { verbose: false, });
+	let errors = outputMessages.filter(function isError(msg) { return msg.type == "error"; });
+	// assert.equal(outputMessages.length, 15, "total output length");
+	assert.equal(errors.length, 2, "num errors");
+});
+
+QUnit.test("Checker: #39 Non-empty arrays", function test(assert) {
+	assert.expect(1);
+	let code = `
+		var x = array\`int[]\`\`\${ [] }\`;		// OK, allowed to be empty
+		var y = array\`int[+]\`\`\${ [] }\`;		// error, not allowed to be empty
+		y = [] // error
+	`;
+	let { outputMessages, } = TL.Checker.check(code, { verbose: false, });
+	let errors = outputMessages.filter(function isError(msg) { return msg.type == "error"; });
+	// assert.equal(outputMessages.length, 21, "total output length");
+	assert.equal(errors.length, 2, "num errors");
+});
+
+QUnit.test("Checker: #39 Array of various types (union types)", function test(assert) {
+	assert.expect(1);
+	let code = `
+		var x = array\`(int | string)[]\`;
+		x = [ 1, 2, "hello", 4 ];		// OK!
+		x = [ 1, 2, true, 4 ];			// error
+	`;
+	let { outputMessages, } = TL.Checker.check(code, { verbose: false, });
+	let errors = outputMessages.filter(function isError(msg) { return msg.type == "error"; });
+	// assert.equal(outputMessages.length, 25, "total output length");
+	assert.equal(errors.length, 1, "num errors");
+});
+
+QUnit.test("Checker: #39 multidimensional arrays", function test(assert) {
+	assert.expect(1);
+	let code = `
+		var x = array\`int[][]\`;
+		var y = array\`int[][][]\`;
+		var z = array\`(int | string)[][]\`;
+		
+		x = [
+			[1,2,3],
+			[4],
+			[5,6],
+			[7,8,9,10]
+		];   // OK!
+		
+		y = [
+			[
+				[1,2,3],
+				[4,5,6],
+				[7,8,9]
+			],
+			[
+				[1,0,0],
+				[0,1,0],
+				[0,0,1]
+			]
+		];   // OK!
+		
+		z = [
+			[1,"hello"],
+			[2,3,"world"],
+			["ok"],
+			[42]
+		];   // OK!
+	`;
+	let { outputMessages, } = TL.Checker.check(code, { verbose: false, });
+	let errors = outputMessages.filter(function isError(msg) { return msg.type == "error"; });
+	// assert.equal(outputMessages.length,47,"total output length");
+	assert.equal(errors.length, 0, "num errors");
+});
+
+QUnit.test("Checker: #39 Tuple, Nested Tuple", function test(assert) {
+	assert.expect(1);
+	let code = `
+		var x = array\`<int,string>\`;
+		var y = array\`<<int,string>,bool>\`;
+		
+		x = [ 42, "hello world" ];   // OK!
+		y = [ x, true ];   // OK!
+	`;
+	let { outputMessages, } = TL.Checker.check(code, { verbose: false, });
+	let errors = outputMessages.filter(function isError(msg) { return msg.type == "error"; });
+	// assert.equal(outputMessages.length,25,"total output length");
+	assert.equal(errors.length, 1, "num errors");
+});
+
+QUnit.test("Checker: #39 Array of tuples", function test(assert) {
+	assert.expect(1);
+	let code = `
+		var x = array\`<int,string>[]\`;
+		x = [
+			[42,"hello"],
+			[10,"world"]
+		]; 
+	`;
+	let { outputMessages, } = TL.Checker.check(code, { verbose: false, });
+	let errors = outputMessages.filter(function isError(msg) { return msg.type == "error"; });
+	// assert.equal(outputMessages.length,25,"total output length");
+	assert.equal(errors.length, 0, "num errors");
+});
+
+
+QUnit.test("Checker: #39 Tuple of arrays", function test(assert) {
+	assert.expect(1);
+	let code = `
+		var x = array\`<int,string>[]\`;
+		x = [
+			[42,"hello"],
+			[10,"world"]
+		]; 
+	`;
+	let { outputMessages, } = TL.Checker.check(code, { verbose: false, });
+	let errors = outputMessages.filter(function isError(msg) { return msg.type == "error"; });
+	// assert.equal(outputMessages.length,25,"total output length");
+	assert.equal(errors.length, 0, "num errors");
+});
+
+QUnit.test("Checker: #39 Array of tuples of arrays", function test(assert) {
+	assert.expect(1);
+	let code = `
+		var x = array\`<int[],string[]>[]\`;
+		x = [
+			[
+				[1,2,3,4],
+				["hello","world"]
+			],
+			[
+				[5,6],
+				[]
+			],
+			[
+				[7],
+				["very","cool","stuff"]
+			]
+		];   // OK!
+	`;
+	let { outputMessages, } = TL.Checker.check(code, { verbose: false, });
+	let errors = outputMessages.filter(function isError(msg) { return msg.type == "error"; });
+	// assert.equal(outputMessages.length,25,"total output length");
+	assert.equal(errors.length, 0, "num errors");
+});


### PR DESCRIPTION
I made the tests for Array stuff. You will see there are errors happening from tuple onwards.

Basically in a case like this, it finds errors in both assignments, instead of just the bottom one.

```
var x = array`(int | string)[]`;
x = [ 1, 2, "hello", 4 ];		// OK!
x = [ 1, 2, true, 4 ];			// error
```

This is because it recognizes the array as type `any` instead of type of ints and/or strings.

